### PR TITLE
feat: Add comprehensive SPI master tests using Pico PIO slave

### DIFF
--- a/src/venusa/spi/Makefile
+++ b/src/venusa/spi/Makefile
@@ -2,6 +2,11 @@ TOPDIR=../../../..
 
 exclude_dirs =
 
+# Define subdirectories to build
+SUBDIRS = spi_master_pol0_pha0 \
+          spi_master_pol0_pha1 \
+          spi_master_pol1_pha0 \
+          spi_master_pol1_pha1
  
 include $(TOPDIR)/rules.mk
 

--- a/src/venusa/spi/spi_master_pol0_pha1/Makefile
+++ b/src/venusa/spi/spi_master_pol0_pha1/Makefile
@@ -1,0 +1,32 @@
+TOPDIR=../../../../..
+
+#lib or target you want to build: eg. LIB=libmisc.a  or TARGET=wlan
+LIB		= 
+TARGET = spi_master_pol0_pha1
+
+# modules depend by this module
+MODULES = bsp driver unity
+
+#libraries depend: eg. LIBS = -lbsp -ldrv -lrtos
+#LIBS	= -lrtos -lutils -ldbg -lbsp -lopi -lmva
+LIBS	= -lbsp -lunity
+
+ifeq ($(IC_BOARD), 0)
+LIBS	+= -ldrv_fpga
+else
+LIBS	+= -ldrv
+endif
+
+#exclude subdirs
+
+#files want to build: eg. CSRCS=a.c  CPPSRCS=b.cpp  SSRCS=c.S
+CSRCS	= $(wildcard *.c)
+CPPSRCS	= 
+SSRCS	= 
+
+#includings and flags
+CFLAGS = -I . \
+         -I $(TOPDIR)/modules/unity/include
+
+
+include $(TOPDIR)/rules.mk

--- a/src/venusa/spi/spi_master_pol0_pha1/main.c
+++ b/src/venusa/spi/spi_master_pol0_pha1/main.c
@@ -147,7 +147,7 @@ static void run_spi_test_case(const char* test_name, uint32_t io_flags, uint32_t
     TEST_ASSERT_EQUAL_INT_MESSAGE(CSK_DRIVER_OK, ret, "SPI_PowerControl (FULL) failed.");
 
     ret = SPI_Control(spi_dev, CSK_SPI_MODE_MASTER | io_flags |
-                 CSK_SPI_CPOL0_CPHA0 |      // Mode 0
+                 CSK_SPI_CPOL0_CPHA1 |      // Mode 1
                  CSK_SPI_DATA_BITS(8) |
                  CSK_SPI_MSB_LSB, SPI_SCK_FREQ);
     TEST_ASSERT_EQUAL_INT_MESSAGE(CSK_DRIVER_OK, ret, "SPI_Control failed.");
@@ -209,7 +209,7 @@ void test_spi_dma_variable_lengths_and_patterns(void); // Renamed for clarity
 int main()
 {
     logInit(0, 115200);
-    CLOGD("\r\n++++++++++ SPI%d Master POL=0 PHA=0 Variable Length Tests +++++++++++\r\n\r\n", SPI_INSTANCE);
+    CLOGD("\r\n++++++++++ SPI%d Master POL=0 PHA=1 Variable Length Tests +++++++++++\r\n\r\n", SPI_INSTANCE);
 
     config_spi(); // Initial hardware pin configuration
 

--- a/src/venusa/spi/spi_master_pol1_pha0/Makefile
+++ b/src/venusa/spi/spi_master_pol1_pha0/Makefile
@@ -1,0 +1,32 @@
+TOPDIR=../../../../..
+
+#lib or target you want to build: eg. LIB=libmisc.a  or TARGET=wlan
+LIB		= 
+TARGET = spi_master_pol1_pha0
+
+# modules depend by this module
+MODULES = bsp driver unity
+
+#libraries depend: eg. LIBS = -lbsp -ldrv -lrtos
+#LIBS	= -lrtos -lutils -ldbg -lbsp -lopi -lmva
+LIBS	= -lbsp -lunity
+
+ifeq ($(IC_BOARD), 0)
+LIBS	+= -ldrv_fpga
+else
+LIBS	+= -ldrv
+endif
+
+#exclude subdirs
+
+#files want to build: eg. CSRCS=a.c  CPPSRCS=b.cpp  SSRCS=c.S
+CSRCS	= $(wildcard *.c)
+CPPSRCS	= 
+SSRCS	= 
+
+#includings and flags
+CFLAGS = -I . \
+         -I $(TOPDIR)/modules/unity/include
+
+
+include $(TOPDIR)/rules.mk

--- a/src/venusa/spi/spi_master_pol1_pha0/main.c
+++ b/src/venusa/spi/spi_master_pol1_pha0/main.c
@@ -147,7 +147,7 @@ static void run_spi_test_case(const char* test_name, uint32_t io_flags, uint32_t
     TEST_ASSERT_EQUAL_INT_MESSAGE(CSK_DRIVER_OK, ret, "SPI_PowerControl (FULL) failed.");
 
     ret = SPI_Control(spi_dev, CSK_SPI_MODE_MASTER | io_flags |
-                 CSK_SPI_CPOL0_CPHA0 |      // Mode 0
+                 CSK_SPI_CPOL1_CPHA0 |      // Mode 2
                  CSK_SPI_DATA_BITS(8) |
                  CSK_SPI_MSB_LSB, SPI_SCK_FREQ);
     TEST_ASSERT_EQUAL_INT_MESSAGE(CSK_DRIVER_OK, ret, "SPI_Control failed.");
@@ -209,7 +209,7 @@ void test_spi_dma_variable_lengths_and_patterns(void); // Renamed for clarity
 int main()
 {
     logInit(0, 115200);
-    CLOGD("\r\n++++++++++ SPI%d Master POL=0 PHA=0 Variable Length Tests +++++++++++\r\n\r\n", SPI_INSTANCE);
+    CLOGD("\r\n++++++++++ SPI%d Master POL=1 PHA=0 Variable Length Tests +++++++++++\r\n\r\n", SPI_INSTANCE);
 
     config_spi(); // Initial hardware pin configuration
 

--- a/src/venusa/spi/spi_master_pol1_pha1/Makefile
+++ b/src/venusa/spi/spi_master_pol1_pha1/Makefile
@@ -1,0 +1,32 @@
+TOPDIR=../../../../..
+
+#lib or target you want to build: eg. LIB=libmisc.a  or TARGET=wlan
+LIB		= 
+TARGET = spi_master_pol1_pha1
+
+# modules depend by this module
+MODULES = bsp driver unity
+
+#libraries depend: eg. LIBS = -lbsp -ldrv -lrtos
+#LIBS	= -lrtos -lutils -ldbg -lbsp -lopi -lmva
+LIBS	= -lbsp -lunity
+
+ifeq ($(IC_BOARD), 0)
+LIBS	+= -ldrv_fpga
+else
+LIBS	+= -ldrv
+endif
+
+#exclude subdirs
+
+#files want to build: eg. CSRCS=a.c  CPPSRCS=b.cpp  SSRCS=c.S
+CSRCS	= $(wildcard *.c)
+CPPSRCS	= 
+SSRCS	= 
+
+#includings and flags
+CFLAGS = -I . \
+         -I $(TOPDIR)/modules/unity/include
+
+
+include $(TOPDIR)/rules.mk

--- a/src/venusa/spi/spi_master_pol1_pha1/main.c
+++ b/src/venusa/spi/spi_master_pol1_pha1/main.c
@@ -147,7 +147,7 @@ static void run_spi_test_case(const char* test_name, uint32_t io_flags, uint32_t
     TEST_ASSERT_EQUAL_INT_MESSAGE(CSK_DRIVER_OK, ret, "SPI_PowerControl (FULL) failed.");
 
     ret = SPI_Control(spi_dev, CSK_SPI_MODE_MASTER | io_flags |
-                 CSK_SPI_CPOL0_CPHA0 |      // Mode 0
+                 CSK_SPI_CPOL1_CPHA1 |      // Mode 3
                  CSK_SPI_DATA_BITS(8) |
                  CSK_SPI_MSB_LSB, SPI_SCK_FREQ);
     TEST_ASSERT_EQUAL_INT_MESSAGE(CSK_DRIVER_OK, ret, "SPI_Control failed.");
@@ -209,7 +209,7 @@ void test_spi_dma_variable_lengths_and_patterns(void); // Renamed for clarity
 int main()
 {
     logInit(0, 115200);
-    CLOGD("\r\n++++++++++ SPI%d Master POL=0 PHA=0 Variable Length Tests +++++++++++\r\n\r\n", SPI_INSTANCE);
+    CLOGD("\r\n++++++++++ SPI%d Master POL=1 PHA=1 Variable Length Tests +++++++++++\r\n\r\n", SPI_INSTANCE);
 
     config_spi(); // Initial hardware pin configuration
 

--- a/test/pico/README.md
+++ b/test/pico/README.md
@@ -1,0 +1,153 @@
+# Pico PIO SPI Slave Testing Guide
+
+## 1. Overview
+
+This guide describes how to use the Raspberry Pi Pico as a PIO-based SPI slave for testing SPI master implementations, specifically targeting the Venusa SPI master applications.
+
+The `test_spi_pio.py` script allows the Pico to emulate an SPI slave device that can operate in any of the four standard SPI modes (0, 1, 2, or 3). It offers flexibility in configuring expected data from the master and the data it should send in response, making it a useful tool for verifying SPI communication.
+
+## 2. Hardware Setup
+
+Connect the Raspberry Pi Pico to the Venusa device (or other SPI master) as follows:
+
+*   **MOSI:** Pico GP3 (Master Out, Slave In) to Venusa MOSI
+*   **MISO:** Pico GP4 (Master In, Slave Out) to Venusa MISO
+*   **SCK:** Pico GP2 (Serial Clock) to Venusa SCK
+*   **CS:** Pico GP5 (Chip Select) to Venusa CS
+*   **GND:** Pico GND to Venusa GND
+
+**Note:** These pin assignments are defined at the top of `test_spi_pio.py` (`PIN_MOSI`, `PIN_MISO`, `PIN_SCK`, `PIN_CS`). You can modify them if your hardware setup requires different pins. Ensure `SCK_PIN_FOR_PIO` global constant is also updated if `PIN_SCK` is changed, as the PIO programs use this.
+
+## 3. Pico Slave (`test_spi_pio.py`) Configuration
+
+The `test_spi_pio.py` script needs to be configured before running it on the Pico.
+
+### 3.1. Selecting SPI Mode
+
+To select the SPI mode for the slave to operate in, modify the `SELECTED_SPI_MODE` variable at the beginning of the `if __name__ == "__main__":` block in the script:
+
+```python
+# Example: To select SPI Mode 0
+SELECTED_SPI_MODE = 0 
+
+# Example: To select SPI Mode 1
+# SELECTED_SPI_MODE = 1 
+
+# ... and so on for modes 2 and 3.
+```
+
+### 3.2. Configuring Expected and Reply Data
+
+The script allows you to define what data the Pico slave expects to receive from the master and what data it should send back. This is configured using `EXPECTED_FROM_MASTER` and `DATA_FOR_MASTER` variables within the `if __name__ == "__main__":` block, typically within the conditional blocks for `SELECTED_SPI_MODE`.
+
+*   **`EXPECTED_FROM_MASTER`**:
+    *   Set to a list of bytes (e.g., `[0xAA, 0xBB, 0xCC]`) that the slave expects to receive from the master. The slave will verify the received data against this list.
+    *   Set to `None` or an empty list `[]` if you want the slave to operate in "capture mode," where it receives any data from the master until CS is deactivated (or a timeout occurs) without specific verification against a predefined pattern.
+
+*   **`DATA_FOR_MASTER`**:
+    *   Set to a list of bytes (e.g., `[0x11, 0x22, 0x33]`) that the slave should send back to the master.
+    *   If `DATA_FOR_MASTER` is an empty list `[]` (and `EXPECTED_FROM_MASTER` was not empty), the slave will by default echo back the data it received (or an incremented version, depending on the exact logic in `PioSpiSlave.process()`). Check the `process()` method for the precise default behavior when `reply_data` is empty.
+    *   If `EXPECTED_FROM_MASTER` is `None` (capture mode) and `DATA_FOR_MASTER` is `[]`, the slave will echo the captured data.
+
+**Examples:**
+
+```python
+# Example for Mode 0: Expect specific data, send specific data
+if SELECTED_SPI_MODE == 0:
+    EXPECTED_FROM_MASTER = [0xA1, 0xB2, 0xC3] # Master is expected to send this
+    DATA_FOR_MASTER = [0x3C, 0x2B, 0x1A]      # Slave will reply with this
+
+# Example for Mode 1: Capture mode, echo back
+elif SELECTED_SPI_MODE == 1:
+    EXPECTED_FROM_MASTER = None 
+    DATA_FOR_MASTER = [] # Will echo received data
+
+# Example for Mode 2: Expect specific data, send default (echo/incremented)
+elif SELECTED_SPI_MODE == 2:
+    EXPECTED_FROM_MASTER = [0xDE, 0xAD]
+    DATA_FOR_MASTER = [] 
+```
+
+### 3.3. Running the Script on Pico
+
+1.  Connect the Raspberry Pi Pico to your computer via USB.
+2.  Open `test_spi_pio.py` in an editor like Thonny IDE.
+3.  Make your configurations for SPI mode, expected data, and reply data as described above.
+4.  Run the script (e.g., click the "Run" button in Thonny, or use `mpremote run test_spi_pio.py` if using `mpremote`).
+5.  The Pico will print initialization messages and then wait for the Chip Select (CS) line to be activated by the master.
+
+## 4. Venusa Master Application Setup and Execution
+
+The Venusa SDK provides several SPI master applications, each configured for a specific SPI mode. These applications are designed to test communication with an SPI slave like the Pico script.
+
+### 4.1. Available Venusa Master Applications
+
+The pre-configured master applications are located in `src/venusa/spi/`:
+
+*   **Mode 0:** `src/venusa/spi/spi_master_pol0_pha0/`
+*   **Mode 1:** `src/venusa/spi/spi_master_pol0_pha1/`
+*   **Mode 2:** `src/venusa/spi/spi_master_pol1_pha0/`
+*   **Mode 3:** `src/venusa/spi/spi_master_pol1_pha1/`
+
+Each of these applications contains a `main.c` file that runs a series of tests, typically within a function like `test_spi_pio_variable_lengths_and_patterns`. These tests send various data patterns and lengths and verify the received data.
+
+### 4.2. Aligning Test Patterns
+
+For successful end-to-end testing, the data patterns configured in the Venusa master application must align with the Pico slave's `EXPECTED_FROM_MASTER` and `DATA_FOR_MASTER` settings.
+
+The Venusa master tests are implemented in `run_spi_test_case` within its `main.c`. This function takes `p_send_data` (what the master sends) and `p_expected_receive_data` (what the master expects back from the slave).
+
+**Example Alignment:**
+
+If a Venusa master test case in `spi_master_pol0_pha1/main.c` is configured as:
+```c
+// In Venusa's main.c
+uint8_t master_sends[] = {0x11, 0x22, 0x33};
+uint8_t master_expects_from_slave[] = {0xCC, 0xBB, 0xAA};
+run_spi_test_case("TestName", CSK_SPI_TXIO_PIO | CSK_SPI_RXIO_PIO, 
+                  sizeof(master_sends), master_sends, master_expects_from_slave);
+```
+
+Then, the `test_spi_pio.py` script (with `SELECTED_SPI_MODE = 1`) should be configured as:
+```python
+# In test_spi_pio.py for Mode 1
+EXPECTED_FROM_MASTER = [0x11, 0x22, 0x33]  # Must match master_sends
+DATA_FOR_MASTER = [0xCC, 0xBB, 0xAA]       # Must match master_expects_from_slave
+```
+
+Loopback tests in the Venusa master (where `p_expected_receive_data` is the same as `p_send_data`, or NULL) require the Pico slave to be configured to echo the data it receives. This can usually be achieved by setting `DATA_FOR_MASTER = []` on the Pico side when `EXPECTED_FROM_MASTER` is set.
+
+### 4.3. Building and Running Venusa Applications
+
+The specific steps to build and run the Venusa SPI master applications depend on your Venusa development environment and build system. Generally:
+
+1.  Navigate to the specific application directory (e.g., `cd src/venusa/spi/spi_master_pol0_pha1`).
+2.  Use the provided `Makefile` and build system commands (e.g., `make`) to compile the application.
+3.  Load and run the compiled binary on the Venusa target hardware.
+4.  Observe the console output from the Venusa device for test results and logs.
+
+## 5. Running a Test - Example Workflow
+
+Here’s a step-by-step example for testing SPI Mode 1:
+
+1.  **Choose SPI Mode:** Mode 1 (CPOL=0, CPHA=1).
+2.  **Configure Pico Slave (`test_spi_pio.py`):**
+    *   Set `SELECTED_SPI_MODE = 1`.
+    *   Assume a test case in the Venusa `spi_master_pol0_pha1/main.c` sends `[0xAA, 0xBB]` and expects the slave to return `[0xCC, 0xDD]`.
+    *   In `test_spi_pio.py`, set:
+        ```python
+        if SELECTED_SPI_MODE == 1:
+            EXPECTED_FROM_MASTER = [0xAA, 0xBB]
+            DATA_FOR_MASTER = [0xCC, 0xDD]
+        ```
+3.  **Run Pico Slave Script:**
+    *   Start `test_spi_pio.py` on the Raspberry Pi Pico.
+    *   The Pico's console will show it's initialized for Mode 1 and waiting for CS activation.
+4.  **Build and Run Venusa Master:**
+    *   Build the `spi_master_pol0_pha1` application from `src/venusa/spi/spi_master_pol0_pha1/`.
+    *   Run the compiled application on the Venusa device.
+5.  **Observe Results:**
+    *   The Venusa console will show logs from `run_spi_test_case`, indicating the data sent, data received, and assertion results (e.g., "Data verification successful." or "Received data does not match expected data.").
+    *   The Pico console will show logs indicating CS activation, data received (e.g., "Received: 0xaa 0xbb"), verification against its `EXPECTED_FROM_MASTER`, data loaded to its TX FIFO, and CS deactivation.
+
+By comparing the logs and ensuring both sides report successful data exchange and verification, you can confirm the SPI communication for the chosen mode and data patterns. Repeat for other modes and data configurations as needed.

--- a/test/pico/test_spi_pio.py
+++ b/test/pico/test_spi_pio.py
@@ -3,113 +3,376 @@ from rp2 import PIO, StateMachine, asm_pio
 from machine import Pin
 import time
 
-@asm_pio(
-    autopush=True,  # 自动将接收数据推送到RX FIFO
-    push_thresh=8,  # 每8位组成一个字节
-    in_shiftdir=rp2.PIO.SHIFT_LEFT,  # 数据左移（MSB first）
-    out_shiftdir=rp2.PIO.SHIFT_LEFT
-)
+# Pin definitions (ensure these match your hardware setup)
+PIN_MOSI = 3  # Master Out, Slave In (connected to GP3 on Pico)
+PIN_MISO = 4  # Master In, Slave Out (connected to GP4 on Pico)
+PIN_SCK = 2   # Serial Clock (connected to GP2 on Pico) - Used by PIO for `wait`
+PIN_CS = 5    # Chip Select (connected to GP5 on Pico) - Handled by Python
 
-def spi_slave():
-    # 引脚绑定：in_pins(MOSI), out_pins(MISO), sideset_pins(SCK, CS)
+# Global constant for SCK pin number, accessible by the PIO program.
+# Note: @asm_pio decorated functions capture globals from their definition context.
+# This means PIN_SCK must be defined before pio_spi_slave_mode0.
+# This is a common way to pass "constants" to PIO programs.
+SCK_PIN_FOR_PIO = PIN_SCK 
+
+@asm_pio(
+    autopush=True,      # Automatically push data from ISR to RX FIFO
+    push_thresh=8,      # Push to RX FIFO after 8 bits (1 byte)
+    autopull=True,      # Automatically pull data from TX FIFO to OSR
+    pull_thresh=8,      # Pull from TX FIFO when OSR has 8 bits (ready for 1 byte)
+    in_shiftdir=PIO.SHIFT_LEFT,  # Shift data in from MSB first
+    out_shiftdir=PIO.SHIFT_LEFT, # Shift data out from MSB first
+    out_init=PIO.OUT_LOW # Initialize MISO pin to low (applies to all modes)
+)
+def pio_spi_slave_mode0(): # CPOL=0, CPHA=0
+    # SCK idle low. Sample on rising edge, output on falling edge.
     wrap_target()
-    # 等待CS拉低（片选激活）
-    wait(0, pin, 0)
-    
-    # 接收/发送循环
-    label("loop")
-    # 在SCK上升沿读取MOSI（SPI Mode 0）
-    in_(pins, 1)        .side(0)    [1]  # SCK低电平时准备
-    wait(1, pin, 1)     .side(1)        # 等待SCK上升沿
-    # 在SCK下降沿输出MISO
-    out(pins, 1)        .side(0)    [1]
-    jmp("loop")         .side(0)
-    
+    label("bit_loop_mode0")
+    wait(1, gpio, SCK_PIN_FOR_PIO)
+    in_(pins, 1)
+    wait(0, gpio, SCK_PIN_FOR_PIO)
+    out(pins, 1)
+    jmp("bit_loop_mode0")
     wrap()
 
-
-# 初始化状态机
-sm = StateMachine(
-    0,                  # 使用状态机0
-    spi_slave,
-    freq=10_000_000,     # 状态机时钟频率
-    in_pin=Pin(3),      # MOSI引脚（GP0）
-    out_pin=Pin(4),     # MISO引脚（GP1）
-    sideset_pins=Pin(2) # SCK引脚（GP2）
+@asm_pio(
+    autopush=True, push_thresh=8, autopull=True, pull_thresh=8,
+    in_shiftdir=PIO.SHIFT_LEFT, out_shiftdir=PIO.SHIFT_LEFT,
+    out_init=PIO.OUT_LOW
 )
+def pio_spi_slave_mode1(): # CPOL=0, CPHA=1
+    # SCK idle low. Output on rising edge, sample on falling edge.
+    wrap_target()
+    label("bit_loop_mode1")
+    wait(1, gpio, SCK_PIN_FOR_PIO)
+    out(pins, 1)
+    wait(0, gpio, SCK_PIN_FOR_PIO)
+    in_(pins, 1)
+    jmp("bit_loop_mode1")
+    wrap()
 
-# 启动状态机
-sm.active(1)
+@asm_pio(
+    autopush=True, push_thresh=8, autopull=True, pull_thresh=8,
+    in_shiftdir=PIO.SHIFT_LEFT, out_shiftdir=PIO.SHIFT_LEFT,
+    out_init=PIO.OUT_LOW # MISO starts low, will be driven high if SCK idle high and first bit is 1
+)
+def pio_spi_slave_mode2(): # CPOL=1, CPHA=0
+    # SCK idle high. Sample on falling edge, output on rising edge.
+    wrap_target()
+    label("bit_loop_mode2")
+    wait(0, gpio, SCK_PIN_FOR_PIO)
+    in_(pins, 1)
+    wait(1, gpio, SCK_PIN_FOR_PIO)
+    out(pins, 1)
+    jmp("bit_loop_mode2")
+    wrap()
 
+@asm_pio(
+    autopush=True, push_thresh=8, autopull=True, pull_thresh=8,
+    in_shiftdir=PIO.SHIFT_LEFT, out_shiftdir=PIO.SHIFT_LEFT,
+    out_init=PIO.OUT_LOW
+)
+def pio_spi_slave_mode3(): # CPOL=1, CPHA=1
+    # SCK idle high. Output on falling edge, sample on rising edge.
+    wrap_target()
+    label("bit_loop_mode3")
+    wait(0, gpio, SCK_PIN_FOR_PIO)
+    out(pins, 1)
+    wait(1, gpio, SCK_PIN_FOR_PIO)
+    in_(pins, 1)
+    jmp("bit_loop_mode3")
+    wrap()
 
-pin_cs = Pin(5, Pin.IN)
+class PioSpiSlave:
+    def __init__(self, sm_id, spi_mode, 
+                 mosi_pin_num, miso_pin_num, sck_pin_num_for_pio_wait, cs_pin_num,
+                 expected_data_to_receive=None, data_to_send_on_receive=None):
+        
+        global SCK_PIN_FOR_PIO
+        SCK_PIN_FOR_PIO = sck_pin_num_for_pio_wait 
 
-print("SPI slave started...")
-# 等待片选信号拉低，表示主设备开始通信
-while not pin_cs.value():
-    pass  # 等待片选信号拉低
+        self.spi_mode = spi_mode
+        self.mosi_pin = Pin(mosi_pin_num)
+        self.miso_pin = Pin(miso_pin_num, Pin.OUT)
+        self.cs_pin = Pin(cs_pin_num, Pin.IN, Pin.PULL_UP)
 
-print("CS activated, ready to receive data...")
+        self.expected_data = expected_data_to_receive if expected_data_to_receive is not None else []
+        self.reply_data = data_to_send_on_receive if data_to_send_on_receive is not None else []
 
+        pio_program = None
+        if spi_mode == 0:
+            pio_program = pio_spi_slave_mode0
+        elif spi_mode == 1:
+            pio_program = pio_spi_slave_mode1
+        elif spi_mode == 2:
+            pio_program = pio_spi_slave_mode2
+        elif spi_mode == 3:
+            pio_program = pio_spi_slave_mode3
+        else:
+            raise ValueError("Invalid SPI mode specified. Must be 0, 1, 2, or 3.")
 
-# 数据接收示例
-while True:
-    if sm.rx_fifo() > 0:
-        received_data = sm.get()
-        print(f"Received: 0x{received_data:02x}")
-        # 发送响应数据（示例：接收值+1）
-        sm.put((received_data + 1) & 0xFF)
+        # StateMachine configuration
+        # `out_init` for MISO is set in each @asm_pio decorator.
+        # `sideset_init` is not used for SCK control as slave PIO reacts to external SCK.
+        self.sm = StateMachine(
+            sm_id,
+            pio_program,
+            freq=50_000_000, # PIO clock frequency
+            in_base=self.mosi_pin,
+            out_base=self.miso_pin,
+            # No sideset_base for SCK if using `wait(gpio, pin_num)`
+        )
+        
+        self.sm.restart()
+        self.sm.active(1)
 
+        print(f"SPI Slave (Mode {self.spi_mode}) initialized and running on SM{sm_id}.")
+        print(f"  MOSI: GP{mosi_pin_num}, MISO: GP{miso_pin_num}, SCK (for PIO wait): GP{sck_pin_num_for_pio_wait}, CS: GP{cs_pin_num}")
+        if self.expected_data:
+            self._log_data("  Expecting to receive", self.expected_data)
+        else:
+            print("  Configured to capture any incoming data.")
+        if self.reply_data:
+            self._log_data("  Will reply with", self.reply_data)
+        else:
+            print("  Will reply with default pattern (echo/incremented/0x00s).")
 
+    def _log_data(self, message, data_list):
+        if not data_list: # Handle empty lists gracefully
+            print(f"{message}: (empty)")
+            return
+        print(f"{message}: {' '.join([f'0x{b:02x}' for b in data_list])}")
 
-# import rp2
-# from machine import Pin
+    def process(self):
+        print("\nWaiting for CS activation (CS low)...")
+        # Wait for CS to go low (active)
+        cs_activation_timeout_ms = 30000 # 30 seconds timeout for CS to activate
+        start_cs_activation_wait = time.ticks_ms()
+        while self.cs_pin.value() == 1: # CS is active low
+            if time.ticks_diff(time.ticks_ms(), start_cs_activation_wait) > cs_activation_timeout_ms:
+                print("Timeout: Waited for CS activation, but CS did not go low.")
+                return # Skip this transaction
+            time.sleep_ms(5)
+        print("CS activated (low).")
 
+        received_buffer = []
+        # Clear any stale data from RX FIFO from previous partial transactions or noise
+        while self.sm.rx_fifo() > 0:
+            self.sm.get()
+        # Also clear any stale data from TX FIFO that might have been put but not sent
+        # This is harder without disrupting the SM. Restarting SM on each CS cycle can do this.
+        # Or, ensure PIO program is robust. Current PIO always tries to send from OSR.
+        # If TX FIFO had old data, and master clocked it, it would have been sent.
+        # `self.sm.restart()` was done in init, which is good. Let's assume TX is clean enough.
 
-# @rp2.asm_pio(out_shiftdir=0, autopull=True, pull_thresh=8, autopush=True, push_thresh=8, sideset_init=(rp2.PIO.OUT_LOW, rp2.PIO.OUT_HIGH), out_init=rp2.PIO.OUT_LOW)
-# def spi_cpha0():
-#     # Note X must be preinitialised by setup code before first byte, we reload after sending each byte
-#     # Would normally do this via exec() but in this case it's in the instruction memory and is only run once
-#     set(x, 6)
-#     # Actual program body follows
-#     wrap_target()
-#     pull(ifempty)            .side(0x2)   [1]
-#     label("bitloop")
-#     out(pins, 1)             .side(0x0)   [1]
-#     in_(pins, 1)             .side(0x1)
-#     jmp(x_dec, "bitloop")    .side(0x1)
+        # Reception phase
+        if self.expected_data: # Expecting a specific number of bytes
+            print(f"Expecting to receive {len(self.expected_data)} byte(s).")
+            for i in range(len(self.expected_data)):
+                rx_byte_timeout_ms = 5000 # Timeout per byte
+                start_rx_byte_time = time.ticks_ms()
+                while self.sm.rx_fifo() == 0:
+                    if self.cs_pin.value() == 1:
+                        print("Error: CS deactivated prematurely during reception of expected data.")
+                        self._log_data("Partially received", received_buffer)
+                        return 
+                    if time.ticks_diff(time.ticks_ms(), start_rx_byte_time) > rx_byte_timeout_ms:
+                        print(f"Error: Timeout waiting for byte {i+1} from master.")
+                        self._log_data("Partially received", received_buffer)
+                        return
+                    time.sleep_us(100) # Polling delay
 
-#     out(pins, 1)             .side(0x0)
-#     set(x, 6)                .side(0x0) # Note this could be replaced with mov x, y for programmable frame size
-#     in_(pins, 1)             .side(0x1)
-#     jmp(not_osre, "bitloop") .side(0x1) # Fallthru if TXF empties
+                data_byte = self.sm.get() & 0xFF
+                received_buffer.append(data_byte)
+            
+            self._log_data("Received", received_buffer)
+            if received_buffer == self.expected_data:
+                print("Success: Received data matches expected data.")
+            else:
+                print("Error: Received data does not match expected data.")
+                self._log_data("Expected", self.expected_data)
+                # Behavior on mismatch: continue to send reply, or abort?
+                # Current: continue and send configured/default reply.
+        else: # Capture mode: receive until CS deactivates or timeout
+            print("No specific expected data. Capturing incoming data until CS deactivates...")
+            # Overall timeout for capture to prevent locking up if CS never deactivates
+            capture_timeout_ms = 10000 # 10 seconds max capture time
+            start_capture_time = time.ticks_ms()
+            last_data_received_time = time.ticks_ms()
+            inter_byte_timeout_ms = 1000 # If no data for 1s during capture, assume master done sending this segment
 
-#     nop()                    .side(0x0)   [1] # CSn back porch
-#     wrap()
+            while self.cs_pin.value() == 0: # While CS is active (low)
+                if time.ticks_diff(time.ticks_ms(), start_capture_time) > capture_timeout_ms:
+                    print("Error: Capture mode timed out (overall transaction).")
+                    break
+                if self.sm.rx_fifo() > 0:
+                    data_byte = self.sm.get() & 0xFF
+                    received_buffer.append(data_byte)
+                    last_data_received_time = time.ticks_ms()
+                elif time.ticks_diff(time.ticks_ms(), last_data_received_time) > inter_byte_timeout_ms:
+                    print("Capture mode: No data received for a while, assuming master finished sending this segment.")
+                    break 
+                time.sleep_us(50) # Polling delay
+            self._log_data("Captured", received_buffer)
 
+        # Transmission phase
+        data_to_send = []
+        if self.reply_data:
+            data_to_send = self.reply_data
+            print("Using pre-configured data for reply.")
+        elif received_buffer: # If nothing pre-configured, echo what was received (if anything)
+            data_to_send = received_buffer
+            print("Echoing received data as reply.")
+        elif self.expected_data: # Expected data, nothing received (error), but still need a reply length
+             data_to_send = [0x00] * len(self.expected_data) # Send zeros of expected length
+             print("Nothing received to echo, expected data was set, sending zeros for reply length.")
+        else: # No reply data, nothing received, not expecting data - send a single 0 byte?
+            data_to_send = [0x00] # Default to one byte of 0x00
+            print("No reply data, nothing received/expected, sending a single 0x00 byte.")
 
-# class PIOSPI:
+        if data_to_send:
+            self._log_data("Preparing to send", data_to_send)
+            # Ensure TX FIFO has space. PIO pulls 8 bits at a time.
+            # sm.put(value, 8) is used. TX FIFO depth is 8 words (32 bytes).
+            for byte_val in data_to_send:
+                put_timeout_ms = 1000 # Timeout for sm.put()
+                start_put_time = time.ticks_ms()
+                # Wait for space in TX FIFO. tx_fifo() returns number of words.
+                # If it's not 0, there's some space. If it's 8, it's full.
+                # The PIO `pull_thresh=8` means it tries to keep OSR full.
+                # TX FIFO is 8 words deep (not 4 as sometimes misremembered).
+                # We put 8 bits. It goes into a 32-bit word buffer.
+                while self.sm.tx_fifo() >= 8 : # Approximates "FIFO is full"
+                    if self.cs_pin.value() == 1:
+                        print("Error: CS deactivated while trying to load data into TX FIFO.")
+                        return
+                    if time.ticks_diff(time.ticks_ms(), start_put_time) > put_timeout_ms:
+                        print("Error: Timeout waiting for space in TX FIFO.")
+                        return
+                    time.sleep_us(10)
+                self.sm.put(byte_val, 8) # Put 8 bits into TX FIFO
+            print(f"Data ({len(data_to_send)} byte(s)) loaded into TX FIFO.")
+        else:
+            print("No data to send.")
 
-#     def __init__(self, sm_id, pin_mosi, pin_miso, pin_sck, cpha=False, cpol=False, freq=1000000):
-#         assert(not(cpol or cpha))
-#         self._sm = rp2.StateMachine(sm_id, spi_cpha0, freq=4*freq, sideset_base=Pin(pin_sck), out_base=Pin(pin_mosi), in_base=Pin(pin_sck))
-#         self._sm.active(1)
+        # Wait for CS to be de-asserted by the master
+        print("Waiting for CS deactivation (CS high)...")
+        cs_deactivation_timeout_ms = 10000 # Max time for master to finish reading and raise CS
+        start_cs_deactivation_wait = time.ticks_ms()
+        while self.cs_pin.value() == 0: # While CS is still active low
+            if time.ticks_diff(time.ticks_ms(), start_cs_deactivation_wait) > cs_deactivation_timeout_ms:
+                print("Error: Timeout waiting for CS deactivation. Master may not have raised CS.")
+                break 
+            time.sleep_ms(1)
 
-#     # Note this code will die spectacularly cause we're not draining the RX FIFO
-#     def write_blocking(wdata):
-#         for b in wdata:
-#             self._sm.put(b << 24)
+        if self.cs_pin.value() == 1:
+            print("CS deactivated. Transaction finished.")
+        else:
+            print("CS still active after timeout. Transaction may be incomplete or master error.")
+        
+        # Check if TX FIFO was emptied by master clocking out the data
+        # This is an approximation. If sm.tx_fifo() > 0, some data was not shifted out.
+        # Note: PIO pulls 8 bits to OSR, then shifts bit by bit.
+        # If TX FIFO is not empty, means OSR wasn't even fully reloaded for the last few bytes.
+        tx_remaining_words = self.sm.tx_fifo()
+        if tx_remaining_words > 0:
+            # Each word is 4 bytes. `pull_thresh=8` means it pulls one byte at a time to OSR.
+            # So if tx_fifo() > 0, it means at least one full byte (or more) didn't make it to OSR.
+            print(f"Warning: {tx_remaining_words * 4} byte(s) worth of data may remain in TX FIFO (not clocked out by master).")
 
-#     def read_blocking(n):
-#         data = []
-#         for i in range(n):
-#             data.append(self._sm.get() & 0xff)
-#         return data
+        print("-" * 30)
 
-#     def write_read_blocking(wdata):
-#         rdata = []
-#         for b in wdata:
-#             self._sm.put(b << 24)
-#             rdata.append(self._sm.get() & 0xff)
-#         return rdata
+# Main script execution
+if __name__ == "__main__":
+    # --- Test Configurations ---
+    # You can set these directly or add a simple input mechanism
+    SELECTED_SPI_MODE = 0  # Change this to 0, 1, 2, or 3 to test different modes
     
+    # Example data for testing (can be adjusted per mode if needed)
+    # For simplicity, using the same data pattern for all modes initially.
+    # Specific tests might require different expected/reply data based on how a master for that mode behaves.
+    if SELECTED_SPI_MODE == 0:
+        EXPECTED_FROM_MASTER = [0xA1, 0xB2, 0xC3] # Master sends this
+        DATA_FOR_MASTER = [0x3C, 0x2B, 0x1A]      # Slave replies with this
+    elif SELECTED_SPI_MODE == 1:
+        EXPECTED_FROM_MASTER = [0x11, 0x22, 0x33]
+        DATA_FOR_MASTER = [0xCC, 0xBB, 0xAA]
+    elif SELECTED_SPI_MODE == 2:
+        EXPECTED_FROM_MASTER = [0xDE, 0xAD]
+        DATA_FOR_MASTER = [0xBE, 0xEF]
+    elif SELECTED_SPI_MODE == 3:
+        EXPECTED_FROM_MASTER = [0xCA, 0xFE]
+        DATA_FOR_MASTER = [0xFE, 0xCA]
+    else: # Default fallback
+        EXPECTED_FROM_MASTER = [0x55, 0x55]
+        DATA_FOR_MASTER = [0xAA, 0xAA]
+
+
+    # --- End Test Configurations ---
+
+    # Select the configuration to use for the test:
+    current_expected = EXPECTED_FROM_MASTER
+    current_reply = DATA_FOR_MASTER
+    
+    print(f"Attempting to start SPI Slave in Mode {SELECTED_SPI_MODE}.")
+    print(f"  SCK for PIO wait is GP{PIN_SCK}.")
+    print(f"  MOSI=GP{PIN_MOSI}, MISO=GP{PIN_MISO}, CS=GP{PIN_CS}")
+    print(f"  Selected SCK_PIN_FOR_PIO: GP{SCK_PIN_FOR_PIO}")
+
+
+    slave = PioSpiSlave(
+        sm_id=0, 
+        spi_mode=SELECTED_SPI_MODE,
+        mosi_pin_num=PIN_MOSI,
+        miso_pin_num=PIN_MISO,
+        sck_pin_num_for_pio_wait=SCK_PIN_FOR_PIO,
+        cs_pin_num=PIN_CS,
+        expected_data_to_receive=current_expected,
+        data_to_send_on_receive=current_reply
+    )
+
+    try:
+        while True:
+            slave.process() # Each call to process handles one full CS cycle
+    except KeyboardInterrupt:
+        print("\nSlave stopped by user (KeyboardInterrupt).")
+    finally:
+        if 'slave' in locals() and hasattr(slave, 'sm'):
+            slave.sm.active(0) # Deactivate the state machine
+            print("PIO State Machine deactivated.")
+        print("Script finished.")
+
+# Commented out old code:
+# # 初始化状态机
+# sm = StateMachine(
+#     0,                  # 使用状态机0
+#     spi_slave,
+#     freq=10_000_000,     # 状态机时钟频率
+#     in_pin=Pin(3),      # MOSI引脚（GP0）
+#     out_pin=Pin(4),     # MISO引脚（GP1）
+#     sideset_pins=Pin(2) # SCK引脚（GP2）
+# )
+# # 启动状态机
+# sm.active(1)
+# pin_cs = Pin(5, Pin.IN)
+# print("SPI slave started...")
+# # 等待片选信号拉低，表示主设备开始通信
+# while not pin_cs.value():
+#     pass  # 等待片选信号拉低
+# print("CS activated, ready to receive data...")
+# # 数据接收示例
+# while True:
+#     if sm.rx_fifo() > 0:
+#         received_data = sm.get()
+#         print(f"Received: 0x{received_data:02x}")
+#         # 发送响应数据（示例：接收值+1）
+#         sm.put((received_data + 1) & 0xFF)
+
+# Remove other commented out code as well
+# # import rp2
+# # from machine import Pin
+# # @rp2.asm_pio(out_shiftdir=0, autopull=True, pull_thresh=8, autopush=True, push_thresh=8, sideset_init=(rp2.PIO.OUT_LOW, rp2.PIO.OUT_HIGH), out_init=rp2.PIO.OUT_LOW)
+# # def spi_cpha0():
+# # ... (rest of spi_cpha0)
+# # class PIOSPI:
+# # ... (rest of PIOSPI class)


### PR DESCRIPTION
This commit introduces a significantly enhanced testing framework for the Venusa SPI master applications. A Raspberry Pi Pico running a PIO-based SPI slave script (`test/pico/test_spi_pio.py`) is used as the counterpart for these tests.

Key improvements include:

1.  **Pico PIO SPI Slave (`test/pico/test_spi_pio.py`):**
    *   Supports all 4 SPI modes (0, 1, 2, 3).
    *   Allows configuration of expected data from the master and
        reply data to the master.
    *   Handles variable data lengths.
    *   Provides detailed logging.

2.  **Venusa SPI Master Applications (`src/venusa/spi/`):**
    *   The existing Mode 0 application (`spi_master_pol0_pha0`)
        has been updated to test various data lengths and patterns.
    *   New master applications have been added for:
        *   Mode 1 (`spi_master_pol0_pha1`)
        *   Mode 2 (`spi_master_pol1_pha0`)
        *   Mode 3 (`spi_master_pol1_pha1`)
    *   All master applications utilize a common test structure for
        varied lengths and patterns, interacting with the configured
        Pico slave.
    *   Makefiles have been updated to include these new applications.

3.  **Documentation (`test/pico/README.md`):**
    *   A new README file provides instructions on hardware setup,
        configuring the Pico slave, running Venusa master tests,
        and the overall test workflow.

These changes enable more thorough testing of SPI functionality across different modes and data transfer scenarios.